### PR TITLE
65 bug fix incorrect generation of the index in blog index generate 1 extra button if the las page have 6 elements

### DIFF
--- a/src/website_elements/create_post_card_grid.py
+++ b/src/website_elements/create_post_card_grid.py
@@ -73,18 +73,19 @@ def create_blog_links():
     link_list = ""
 
     pages = get_blog_last_index()
+    print(pages)
     for page in range(0, pages, 1):
         link_list += f"""<a class="blog_link" href="/blog/{page + 1}">{page + 1}</a>"""
     return link_list
 
 
 def get_blog_last_index():
-    lines = sum(1 for line in open("data/post_order.json"))
+    lines = sum(1 for _ in open("data/post_order.json")) - 2  # The two { } of the file
+    print("lineas en el json de post: " + str(lines))
     pages = int(lines / 6)
 
     if lines % 6 != 0:
         pages += 1
-    print(pages)
     return pages
 
 


### PR DESCRIPTION
Bug Fixed.

Reason of the Bug:

The JSON File that contains the Article Name has two additional lines for the brakets, when the program create the index this lines must not be counted.
<img width="696" height="31" alt="image" src="https://github.com/user-attachments/assets/b6f0aa0a-65c0-4a8b-8b58-8b3fa67e0588" />

Send to testing
